### PR TITLE
#3 Fix compiler.parser deprecated warning for webpack 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,11 +38,13 @@ ExtractTranslationPlugin.prototype.apply = function(compiler) {
     var mangleKeys = this.mangleKeys;
     var keys = this.keys = Object.create(null);
     var generator = KeyGenerator.create();
+    var functionName = this.functionName;
 
     compiler.plugin('compilation', function(compilation, params) {
 
         params.normalModuleFactory.plugin('parser', function(parser) {
-            parser.plugin('call ' + this.functionName, function(expr) {
+
+            parser.plugin('call ' + functionName, function(expr) {
                 var key;
                 if (!expr.arguments.length) {
                     this.state.module.errors.push(

--- a/index.js
+++ b/index.js
@@ -87,7 +87,6 @@ ExtractTranslationPlugin.prototype.apply = function(compiler) {
 
     compiler.plugin('done', function() {
         this.done(this.keys);
-        console.log('keys inside plugin', this.keys);
         if (this.output) {
             require('fs').writeFileSync(this.output, JSON.stringify(this.keys));
         }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "index.js",
     "DynamicTranslationKeyError.js",
     "key-generator.js",
-    "NoTranslationKeyError.js"
+    "NoTranslationKeyError.js",
+    "README.md"
   ],
   "repository": {
     "type": "git",
@@ -29,6 +30,7 @@
     "bondjs": "^1.2.2",
     "eslint": "^0.21.2",
     "mocha": "^2.2.5",
-    "webpack": "1.13.1"
+    "tranzlate": "1.2.0",
+    "webpack": "2.1.0-beta.25"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -64,8 +64,10 @@ describe('Webpack Extract Translations Keys', function () {
             });
             const compiler = createFakeCompiler();
             pl.apply(compiler);
-            assert.equal(compiler.plugin.calledArgs[0][0], 'done');
-            compiler.plugin.calledArgs[0][1]();
+            // console.log('compiler and plugin', compiler.plugin.calledArgs);
+            assert.equal(compiler.plugin.calledArgs[0][0], 'compilation');
+            assert.equal(compiler.plugin.calledArgs[1][0], 'done');
+            compiler.plugin.calledArgs[1][1]();
             assert.equal(spy.calledArgs[0][0], pl.keys);
         });
 
@@ -73,80 +75,100 @@ describe('Webpack Extract Translations Keys', function () {
             const pl = new Plugin();
             const compiler = createFakeCompiler();
             pl.apply(compiler);
-            const parserCallback = compiler.parser.plugin.calledArgs[0][1];
-            const ctx = createContext();
+            compiler.plugin('compilation', function(compilation, params) {
+                params.normalModuleFactory.plugin('parser', function(parser) {
+                    const parserCallback = parser.plugin.calledArgs[0][1];
+                    const ctx = createContext();
 
-            parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key1' }]));
-            parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key2' }]));
-            parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key3' }]));
+                    parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key1' }]));
+                    parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key2' }]));
+                    parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key3' }]));
 
-            assert.deepEqual(pl.keys, {'key1': 'key1', 'key2': 'key2', 'key3': 'key3'});
+                    assert.deepEqual(pl.keys, {'key1': 'key1', 'key2': 'key2', 'key3': 'key3'});
+                });
+            });
         });
 
         it('should eliminate duplicates when it collecting keys', function () {
             const pl = new Plugin();
             const compiler = createFakeCompiler();
             pl.apply(compiler);
-            const parserCallback = compiler.parser.plugin.calledArgs[0][1];
-            const ctx = createContext();
+            compiler.plugin('compilation', function(compilation, params) {
+                params.normalModuleFactory.plugin('parser', function(parser) {
+                    const parserCallback = parser.plugin.calledArgs[0][1];
+                    const ctx = createContext();
 
-            parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key1' }]));
-            parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key1' }]));
-            parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key2' }]));
+                    parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key1' }]));
+                    parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key1' }]));
+                    parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key2' }]));
 
-            assert.deepEqual(pl.keys, {'key1': 'key1', 'key2': 'key2'});
+                    assert.deepEqual(pl.keys, {'key1': 'key1', 'key2': 'key2'});
+                });
+            });
         });
 
         it('should add an error to webpack when translate function does not contain any arguments', function () {
             const pl = new Plugin();
             const compiler = createFakeCompiler();
             pl.apply(compiler);
-            const parserCallback = compiler.parser.plugin.calledArgs[0][1];
-            const expr = createExpression([]);
-            const ctx = createContext();
-            parserCallback.call(ctx, expr);
-            assert.equal(ctx.state.module.errors.length, 1);
-            assert(ctx.state.module.errors[0] instanceof NoTranslationKeyError);
+            compiler.plugin('compilation', function(compilation, params) {
+                params.normalModuleFactory.plugin('parser', function(parser) {
+                    const parserCallback = parser.plugin.calledArgs[0][1];
+                    const expr = createExpression([]);
+                    const ctx = createContext();
+                    parserCallback.call(ctx, expr);
+                    assert.equal(ctx.state.module.errors.length, 1);
+                    assert(ctx.state.module.errors[0] instanceof NoTranslationKeyError);
+                });
+            });
         });
 
         it('should add an error to webpack when first argument of translate function is not a string', function () {
             const pl = new Plugin();
             const compiler = createFakeCompiler();
             pl.apply(compiler);
-            const parserCallback = compiler.parser.plugin.calledArgs[0][1];
-            const ctx = createContext();
-            const arg = {
-                type: 'variable',
-                name: 'foo',
-                value: 'bar'
-            };
-            parserCallback.call(ctx, createExpression([arg]));
-            assert.equal(ctx.state.module.errors.length, 1);
-            assert(ctx.state.module.errors[0] instanceof DynamicTranslationKeyError);
+            compiler.plugin('compilation', function(compilation, params) {
+                params.normalModuleFactory.plugin('parser', function(parser) {
+                    const parserCallback = parser.plugin.calledArgs[0][1];
+                    const ctx = createContext();
+                    const arg = {
+                        type: 'variable',
+                        name: 'foo',
+                        value: 'bar'
+                    };
+                    parserCallback.call(ctx, createExpression([arg]));
+                    assert.equal(ctx.state.module.errors.length, 1);
+                    assert(ctx.state.module.errors[0] instanceof DynamicTranslationKeyError);
+                });
+            });
         });
 
         it('should always return `false` from parser callback to allow further processing of expression', function () {
             const pl = new Plugin();
             const compiler = createFakeCompiler();
             pl.apply(compiler);
-            const parserCallback = compiler.parser.plugin.calledArgs[0][1];
-            const ctx = createContext();
+            compiler.plugin('compilation', function(compilation, params) {
+                params.normalModuleFactory.plugin('parser', function(parser) {
+                    const parserCallback = parser.plugin.calledArgs[0][1];
+                    const ctx = createContext();
 
-            assert.equal(parserCallback.call(ctx, createExpression([])), false);
+                    assert.equal(parserCallback.call(ctx, createExpression([])), false);
 
-            const incorrectArg = {
-                type: 'variable',
-                name: 'foo',
-                value: 'bar'
-            };
-            assert.equal(parserCallback.call(ctx, createExpression([incorrectArg])), false);
+                    const incorrectArg = {
+                        type: 'variable',
+                        name: 'foo',
+                        value: 'bar'
+                    };
+                    assert.equal(parserCallback.call(ctx, createExpression([incorrectArg])), false);
 
-            const correctArg = {
-                type: 'string',
-                name: 'foo',
-                value: 'bar'
-            };
-            assert.equal(parserCallback.call(ctx, createExpression([correctArg])), false);
+                    const correctArg = {
+                        type: 'string',
+                        name: 'foo',
+                        value: 'bar'
+                    };
+                    assert.equal(parserCallback.call(ctx, createExpression([correctArg])), false);
+                });
+            });
         });
     });
 
@@ -157,35 +179,44 @@ describe('Webpack Extract Translations Keys', function () {
             });
             const compiler = createFakeCompiler();
             pl.apply(compiler);
-            const parserCallback = compiler.parser.plugin.calledArgs[0][1];
-            const ctx = createContext();
+            compiler.plugin('compilation', function(compilation, params) {
+                params.normalModuleFactory.plugin('parser', function(parser) {
+                    const parserCallback = parser.plugin.calledArgs[0][1];
+                    const ctx = createContext();
 
-            parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key1' }]));
-            parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key2' }]));
-            parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key3' }]));
+                    parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key1' }]));
+                    parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key2' }]));
+                    parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key3' }]));
 
-            assert.deepEqual(pl.keys, {
-                'key1': ' ',
-                'key2': '!',
-                'key3': '#'
+                    assert.deepEqual(pl.keys, {
+                        'key1': ' ',
+                        'key2': '!',
+                        'key3': '#'
+                    });
+                });
             });
         });
+
         it('should correctly replace all the instances of a certain key with the same value', function () {
             const pl = new Plugin({
                 mangle: true
             });
             const compiler = createFakeCompiler();
             pl.apply(compiler);
-            const parserCallback = compiler.parser.plugin.calledArgs[0][1];
-            const ctx = createContext();
+            compiler.plugin('compilation', function(compilation, params) {
+                params.normalModuleFactory.plugin('parser', function(parser) {
+                    const parserCallback = parser.plugin.calledArgs[0][1];
+                    const ctx = createContext();
 
-            parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key1' }]));
-            parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key1' }]));
+                    parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key1' }]));
+                    parserCallback.call(ctx, createExpression([{ type: 'string', value: 'key1' }]));
 
-            assert.deepStrictEqual(
-                ctx.state.current.addDependency.calledArgs[0],
-                ctx.state.current.addDependency.calledArgs[1]
-            );
+                    assert.deepStrictEqual(
+                        ctx.state.current.addDependency.calledArgs[0],
+                        ctx.state.current.addDependency.calledArgs[1]
+                    );
+                });
+            });
         });
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -64,7 +64,6 @@ describe('Webpack Extract Translations Keys', function () {
             });
             const compiler = createFakeCompiler();
             pl.apply(compiler);
-            // console.log('compiler and plugin', compiler.plugin.calledArgs);
             assert.equal(compiler.plugin.calledArgs[0][0], 'compilation');
             assert.equal(compiler.plugin.calledArgs[1][0], 'done');
             compiler.plugin.calledArgs[1][1]();

--- a/test/system-test.js
+++ b/test/system-test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const webpack = require('webpack');
+const Plugin = require('../index.js');
+const path = require('path');
+const assert = require('assert');
+const fs = require('fs');
+
+describe('Smoke test for the executable script', function() {
+    beforeEach(() => {
+        fs.writeFileSync('test/test-data.js', 'const a = __(\'test.key\');');
+    });
+
+    afterEach(() => {
+        fs.unlinkSync('test/test-data.js');
+        if (fs.existsSync('test/output.js')) {
+            fs.unlinkSync('test/output.js');
+        }
+
+        if (fs.existsSync('test/translation-keys.json')) {
+            fs.unlinkSync('test/translation-keys.json');
+        }
+    });
+
+    describe('when valid input and output file given', function() {
+        it('extracts the keys used in input file', done => {
+            const webpackConfig = {
+                entry: './test/test-data.js',
+                output: {
+                    filename: 'output.js',
+                    path: './test/'
+                },
+                plugins: [
+                    new Plugin({
+                        output: path.join(__dirname, 'translation-keys.json')
+                    }),
+                    new webpack.ProvidePlugin({'__': 'tranzlate'})
+                ]
+            };
+
+            webpack(webpackConfig, (error) => {
+                assert.equal(error, null);
+
+                const content = fs.readFileSync('test/translation-keys.json').toString();
+                assert.equal(content, '{"test.key":"test.key"}');
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
- Fix compiler.parser deprecated warning when using with Webpack 2
- Fix tests for the plugin callback changes 
- Closes #3 