### PR TITLE
Add merge, prettyPrint and newLine options; also allow multiple output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ module.exports = {
 * `output` : false
 * `mangle` : false
 * `merge` : false
+* `newLine` : false
 * `prettyPrint` : 0
 
 ### Error handling

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ module.exports = {
 * `output` : false
 * `mangle` : false
 * `merge` : false
+* `prettyPrint` : 0
 
 ### Error handling
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ In order to be able to map back to the original translation key, the plugin outp
 
 > It's recommended to only enable mangling for production builds, as it makes the debugging harder and also may break hot reloading, depending on your setup.
 
+### Key Merging
+
+By default, this plugin will create a new file at the specified output location.
+To update an existing file with newly added keys, you can turn on the `merge` option.
+
 ### Runtime
 
 Since this plugin doesn't replace function with something else it's up to you to provide function that will actually handle translation in the runtime. It can be a globally defined function or you can use `webpack.ProvidePlugin` inside your configuration:
@@ -104,6 +109,7 @@ module.exports = {
 * `done` : `function (result) {}`
 * `output` : false
 * `mangle` : false
+* `merge` : false
 
 ### Error handling
 

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ function ExtractTranslationPlugin(options) {
     this.functionName = options.functionName || '__';
     this.done = options.done || function () {};
     this.output = typeof options.output === 'string' ? options.output : false;
+    this.merge = options.merge || false;
     this.mangleKeys = options.mangle || false;
 }
 
@@ -89,8 +90,16 @@ ExtractTranslationPlugin.prototype.apply = function(compiler) {
 
     compiler.plugin('done', function() {
         this.done(this.keys);
+
         if (this.output) {
-            require('fs').writeFileSync(this.output, JSON.stringify(this.keys));
+            var data = this.keys;
+            var fs = require('fs');
+
+            if (this.merge && fs.existsSync(this.output)) {
+                data = Object.assign({}, data, require(this.output));
+            }
+
+            fs.writeFileSync(this.output, JSON.stringify(data));
         }
     }.bind(this));
 };

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ function ExtractTranslationPlugin(options) {
     this.done = options.done || function () {};
     this.merge = options.merge || false;
     this.mangleKeys = options.mangle || false;
+    this.newLine = options.newLine || false;
     this.prettyPrint = typeof options.prettyPrint === 'number' ? options.prettyPrint : 0;
     this.output = typeof options.output === 'string'
         ? [options.output] : options.output instanceof Array
@@ -104,7 +105,11 @@ ExtractTranslationPlugin.prototype.apply = function(compiler) {
 
                 this.done(data);
 
-                fs.writeFileSync(file, JSON.stringify(data, null, this.prettyPrint));
+                var result = JSON.stringify(data, null, this.prettyPrint);
+                if (this.newLine) {
+                    result += '\n';
+                }
+                fs.writeFileSync(file, result);
             }.bind(this));
         } else {
             this.done(this.keys);

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ function ExtractTranslationPlugin(options) {
     this.output = typeof options.output === 'string' ? options.output : false;
     this.merge = options.merge || false;
     this.mangleKeys = options.mangle || false;
+    this.prettyPrint = typeof options.prettyPrint === 'number' ? options.prettyPrint : 0;
 }
 
 ExtractTranslationPlugin.prototype.apply = function(compiler) {
@@ -99,7 +100,7 @@ ExtractTranslationPlugin.prototype.apply = function(compiler) {
                 data = Object.assign({}, data, require(this.output));
             }
 
-            fs.writeFileSync(this.output, JSON.stringify(data));
+            fs.writeFileSync(this.output, JSON.stringify(data, null, this.prettyPrint));
         }
     }.bind(this));
 };

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ ExtractTranslationPlugin.prototype.apply = function(compiler) {
             var fs = require('fs');
 
             this.output.forEach(function(file) {
-                var data = this.data;
+                var data = this.keys;
 
                 if (this.merge && fs.existsSync(file)) {
                     data = Object.assign({}, data, require(file));

--- a/index.js
+++ b/index.js
@@ -30,10 +30,12 @@ function ExtractTranslationPlugin(options) {
     options = options || {};
     this.functionName = options.functionName || '__';
     this.done = options.done || function () {};
-    this.output = typeof options.output === 'string' ? options.output : false;
     this.merge = options.merge || false;
     this.mangleKeys = options.mangle || false;
     this.prettyPrint = typeof options.prettyPrint === 'number' ? options.prettyPrint : 0;
+    this.output = typeof options.output === 'string'
+        ? [options.output] : options.output instanceof Array
+            ? options.output : [];
 }
 
 ExtractTranslationPlugin.prototype.apply = function(compiler) {
@@ -92,15 +94,18 @@ ExtractTranslationPlugin.prototype.apply = function(compiler) {
     compiler.plugin('done', function() {
         this.done(this.keys);
 
-        if (this.output) {
-            var data = this.keys;
+        if (this.output.length) {
             var fs = require('fs');
 
-            if (this.merge && fs.existsSync(this.output)) {
-                data = Object.assign({}, data, require(this.output));
-            }
+            this.output.forEach(function(file) {
+                var data = this.data;
 
-            fs.writeFileSync(this.output, JSON.stringify(data, null, this.prettyPrint));
+                if (this.merge && fs.existsSync(file)) {
+                    data = Object.assign({}, data, require(file));
+                }
+
+                fs.writeFileSync(file, JSON.stringify(data, null, this.prettyPrint));
+            }.bind(this));
         }
     }.bind(this));
 };

--- a/index.js
+++ b/index.js
@@ -92,8 +92,6 @@ ExtractTranslationPlugin.prototype.apply = function(compiler) {
     });
 
     compiler.plugin('done', function() {
-        this.done(this.keys);
-
         if (this.output.length) {
             var fs = require('fs');
 
@@ -104,8 +102,12 @@ ExtractTranslationPlugin.prototype.apply = function(compiler) {
                     data = Object.assign({}, data, require(file));
                 }
 
+                this.done(data);
+
                 fs.writeFileSync(file, JSON.stringify(data, null, this.prettyPrint));
             }.bind(this));
+        } else {
+            this.done(this.keys);
         }
     }.bind(this));
 };


### PR DESCRIPTION
The `merge` option will merge the generated keys into an existing file, preserving existing keys and existing translations. Essentially, this updates the file with missing keys. To preserve backward compatibility, this is turned off by default.

The `prettyPrint` option allows the file to be indented by any amount of spaces. To preserve backward compatibility, this is set to zero by default.

The `output` option has been changed to allow multiple output files. This is needed when a project has multiple different language files. To preserve backward compatibility, this still allows a single output entry to be set.

The `newLine` option has been added to end the file with a newline, which is often regarded as a convention. To preserve backward compatibility, this is turned off by default.

I have not written tests as I couldn't figure out how, but did test these changes manually in my project and they work as expected.

This is a pull request as a result of #6.

---

I have also taken a look at #5, but I also didn't get any further. The only thing I was able to find out is that the following line prevents the `I18nPlugin` plugin from working:

```
parser.plugin('call ' + functionName, function(expr) {
  //Doesn't matter what's here
});
```

This happens even if the function body is empty, returns false immediately or returns true immediately.