### PR TITLE
Enable one output per entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ If you run `webpack` now, you should get `dist/translation-keys.json` file with 
 
 It may seems like a waste to output a map with the keys and values being the same thing, the purpose is to keep the output format consistent with the times when the `mangle` option is enabled.
 
+## Output
+
+if output string contains [name], one output file will be created per entry key at corresponding output
+
+
+```js
+// ...
+    plugins: [
+        new ExtractTranslationKeysPlugin({
+            output: path.join(__dirname, 'dist', '[name]/translation-keys.json')
+        })
+    ]
+// ...
+```
+
 ### Key Mangling
 
 In some applications translation keys are quite long, so for the situtations where you want to save some additional bytes in your application, you can enable mangling during the plugin initialization:

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Plugin throw an error if you try to call the translation function without any ar
 
 ## Release Notes
 
+### 5.0.0
+
+Support for multiple output for multiple entries with [name] inside the output string. If [name] is not present, only one output file will be created for all entries
+
 ### 4.0.0
 
 Support for Webpack 4, if you are using Webpack 3, please install 3.x.x version of this plugin. This can be done by running:

--- a/index.js
+++ b/index.js
@@ -16,11 +16,27 @@
 
 'use strict';
 
-var DynamicTranslationKeyError = require('./DynamicTranslationKeyError');
-var NoTranslationKeyError = require('./NoTranslationKeyError');
-var ConstDependency = require('webpack/lib/dependencies/ConstDependency');
-var NullFactory = require('webpack/lib/NullFactory');
-var KeyGenerator = require('./key-generator');
+const DynamicTranslationKeyError = require('./DynamicTranslationKeyError');
+const NoTranslationKeyError = require('./NoTranslationKeyError');
+const ConstDependency = require('webpack/lib/dependencies/ConstDependency');
+const NullFactory = require('webpack/lib/NullFactory');
+const path = require('path');
+const KeyGenerator = require('./key-generator');
+
+// resolve entry for given module, we try to exit early with rawRequest in case of multiple modules issuing request
+function resolveEntry(module, reverseEntryPoints) {
+    let issuer = module;
+    if (reverseEntryPoints[issuer.rawRequest]) {
+        return issuer.rawRequest;
+    }
+    while (issuer.issuer) {
+        issuer = issuer.issuer;
+        if (reverseEntryPoints[issuer.rawRequest]) {
+            return issuer.rawRequest;
+        }
+    }
+    return issuer.rawRequest;
+}
 
 /**
  * @param {Object} options
@@ -29,72 +45,150 @@ var KeyGenerator = require('./key-generator');
 function ExtractTranslationPlugin(options) {
     options = options || {};
     this.functionName = options.functionName || '__';
-    this.done = options.done || function () {};
+    this.done = options.done || function() {};
     this.output = typeof options.output === 'string' ? options.output : false;
     this.mangleKeys = options.mangle || false;
 }
 
 ExtractTranslationPlugin.prototype.apply = function(compiler) {
-    var mangleKeys = this.mangleKeys;
-    var keys = this.keys = Object.create(null);
-    var generator = KeyGenerator.create();
-    var functionName = this.functionName;
+    const mangleKeys = this.mangleKeys;
+    const outputMap = (this.outputMap = new Map());
+    const generator = KeyGenerator.create();
+    const functionName = this.functionName;
 
-    compiler.hooks.compilation.tap('WebpackExtractTranslationKeys', function(compilation) {
+    let entryPoints = {};
+    let reverseEntryPoints = {};
+
+    compiler.hooks.compilation.tap('WebpackExtractTranslationKeys', function(
+        compilation
+    ) {
         compilation.dependencyFactories.set(ConstDependency, new NullFactory());
-        compilation.dependencyTemplates.set(ConstDependency, new ConstDependency.Template());
-    });
+        compilation.dependencyTemplates.set(
+            ConstDependency,
+            new ConstDependency.Template()
+        );
 
-    compiler.hooks.normalModuleFactory.tap('WebpackExtractTranslationKeys', function(factory) {
-
-        factory.hooks.parser.for('javascript/auto').tap('WebpackExtractTranslationKeys', function(parser) {
-
-            parser.hooks.call.for(functionName).tap('WebpackExtractTranslationKeys', function(expr) {
-                var key;
-                if (!expr.arguments.length) {
-                    parser.state.module.errors.push(
-                        new NoTranslationKeyError(parser.state.module, expr)
-                    );
-                    return false;
-                }
-
-                key = parser.evaluateExpression(expr.arguments[0]);
-                if (!key.isString()) {
-                    parser.state.module.errors.push(
-                        new DynamicTranslationKeyError(parser.state.module, expr)
-                    );
-                    return false;
-                }
-
-                key = key.string;
-
-                var value = expr.arguments[0].value;
-
-                if (!(key in keys)) {
-                    if (mangleKeys) {
-                        value = generator.next().value;
-                    }
-                    keys[key] = value;
-                }
-
-                if (mangleKeys) {
-                    // This replaces the original string with the new string
-                    var dep = new ConstDependency(JSON.stringify(keys[key]), expr.arguments[0].range);
-                    dep.loc = expr.arguments[0].loc;
-                    parser.state.current.addDependency(dep);
-                }
-
-                return false;
-            });
-        });
-    });
-
-    compiler.hooks.done.tap('WebpackExtractTranslationKeys', function() {
-        this.done(this.keys);
-        if (this.output) {
-            require('fs').writeFileSync(this.output, JSON.stringify(this.keys));
+        // prepare entryPoints in case of non object syntax
+        entryPoints = compilation.options.entry;
+        if (typeof entryPoints === 'string' || Array.isArray(entryPoints)) {
+            entryPoints = { main: entryPoints };
         }
-    }.bind(this));
+
+        // prepare reverseEntryPoints object for entry resolution of given module
+        reverseEntryPoints = Object.keys(entryPoints).reduce(
+            (reverseEntryPointsAcc, name) => {
+                let entryPoint = entryPoints[name];
+                if (!Array.isArray(entryPoint)) {
+                    entryPoint = [entryPoint];
+                }
+                entryPoint.reduce((acc, curr) => {
+                    acc[curr] = name;
+                    return acc;
+                }, reverseEntryPointsAcc);
+                return reverseEntryPointsAcc;
+            },
+            {}
+        );
+    });
+
+    compiler.hooks.normalModuleFactory.tap(
+        'WebpackExtractTranslationKeys',
+        function(factory) {
+            factory.hooks.parser
+                .for('javascript/auto')
+                .tap('WebpackExtractTranslationKeys', function(parser) {
+                    parser.hooks.call
+                        .for(functionName)
+                        .tap('WebpackExtractTranslationKeys', function(expr) {
+                            let key;
+
+                            if (!expr.arguments.length) {
+                                parser.state.module.errors.push(
+                                    new NoTranslationKeyError(
+                                        parser.state.module,
+                                        expr
+                                    )
+                                );
+                                return false;
+                            }
+
+                            key = parser.evaluateExpression(expr.arguments[0]);
+                            if (!key.isString()) {
+                                parser.state.module.errors.push(
+                                    new DynamicTranslationKeyError(
+                                        parser.state.module,
+                                        expr
+                                    )
+                                );
+                                return false;
+                            }
+
+                            key = key.string;
+
+                            let value = expr.arguments[0].value;
+
+                            const entry =
+                                reverseEntryPoints[
+                                    resolveEntry(
+                                        parser.state.module,
+                                        reverseEntryPoints
+                                    )
+                                ];
+
+                            const entryKeys = outputMap.get(entry) || {};
+                            if (!(key in entryKeys)) {
+                                if (mangleKeys) {
+                                    value = generator.next().value;
+                                }
+                                entryKeys[key] = value;
+                                outputMap.set(entry, entryKeys);
+                            }
+
+                            if (mangleKeys) {
+                                // This replaces the original string with the new string
+                                const dep = new ConstDependency(
+                                    JSON.stringify(value),
+                                    expr.arguments[0].range
+                                );
+                                dep.loc = expr.arguments[0].loc;
+                                parser.state.current.addDependency(dep);
+                            }
+
+                            return false;
+                        });
+                });
+        }
+    );
+
+    compiler.hooks.done.tap(
+        'WebpackExtractTranslationKeys',
+        function() {
+            if (
+                typeof this.output === 'string' &&
+                this.output.includes('[name]')
+            ) {
+                this.done(this.outputMap);
+                this.outputMap.forEach((value, key) => {
+                    require('fs').writeFileSync(
+                        path.resolve(this.output.replace(/\[name\]/g, key)),
+                        JSON.stringify(value)
+                    );
+                });
+            } else {
+                const keys = Array.from(this.outputMap.values()).reduce(
+                    (allKeys, currKeys) => Object.assign({}, allKeys, currKeys),
+                    {}
+                );
+                this.done(keys);
+                if (this.output) {
+                    require('fs').writeFileSync(
+                        this.output,
+                        JSON.stringify(keys)
+                    );
+                }
+            }
+        }.bind(this)
+    );
 };
 
 module.exports = ExtractTranslationPlugin;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-extract-translation-keys-plugin",
-  "version": "3.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3729,18 +3729,18 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -3749,15 +3749,6 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bondjs": "^1.2.2",
     "eslint": "^5.2.0",
     "mocha": "^5.2.0",
+    "rimraf": "^2.6.3",
     "tranzlate": "1.2.0",
     "webpack": "^4.16.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-extract-translation-keys-plugin",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "description": "Webpack plugin to extract list of used translation keys from included modules.",
   "main": "index.js",
   "scripts": {

--- a/test/advanced-test.js
+++ b/test/advanced-test.js
@@ -1,0 +1,297 @@
+'use strict';
+
+const webpack = require('webpack');
+const Plugin = require('../index.js');
+const path = require('path');
+const assert = require('assert');
+const fs = require('fs');
+const rimraf = require('rimraf');
+
+function sortObjectByKeyname(objectToSort) {
+    return Object.keys(objectToSort)
+        .sort()
+        .reduce((r, k) => ((r[k] = objectToSort[k]), r), {});
+}
+
+function runWebpackConfig(
+    webpackConfig,
+    done,
+    translationKeysPath,
+    contentToCompare
+) {
+    webpack(webpackConfig, error => {
+        assert.equal(error, null);
+        const content = JSON.stringify(
+            sortObjectByKeyname(
+                JSON.parse(fs.readFileSync(translationKeysPath, 'utf8'))
+            )
+        );
+        assert.equal(content, contentToCompare);
+        done();
+    });
+}
+
+describe('Smoke test for the executable script', function() {
+    beforeEach(() => {
+        fs.mkdirSync('test/modules');
+        fs.mkdirSync('test/modules/moduleA');
+        fs.mkdirSync('test/modules/moduleB');
+        fs.mkdirSync('test/modules/moduleA/transformer');
+        fs.writeFileSync(
+            'test/modules/moduleA/index.js',
+            `
+require('./transformer/intermediate');
+
+function moduleA() {
+    return __('moduleA');
+}
+`
+        );
+        fs.writeFileSync(
+            'test/modules/moduleB/index.js',
+            `
+function moduleB() {
+    return __('moduleB');
+}            
+`
+        );
+        fs.writeFileSync(
+            'test/modules/moduleA/transformer/intermediate.js',
+            'require(\'./end\');'
+        );
+        fs.writeFileSync(
+            'test/modules/moduleA/transformer/end.js',
+            '__(\'end\');'
+        );
+    });
+
+    afterEach(() => {
+        rimraf.sync('test/modules');
+    });
+
+    describe('when advanced webpack configuration', function() {
+        describe('with a single entry', function() {
+            const webpackConfig = {
+                entry: './test/modules/moduleA/index.js',
+                output: {
+                    filename: 'index.js',
+                    path: path.join(__dirname, 'modules/moduleA')
+                },
+                plugins: [
+                    new Plugin({
+                        output: path.join(
+                            __dirname,
+                            'modules/moduleA/translation-keys.json'
+                        )
+                    })
+                ]
+            };
+
+            it('works with a string', done => {
+                runWebpackConfig(
+                    webpackConfig,
+                    done,
+                    'test/modules/moduleA/translation-keys.json',
+                    '{"end":"end","moduleA":"moduleA"}'
+                );
+            });
+
+            it('works with an object with single key', done => {
+                webpackConfig.entry = {
+                    single: './test/modules/moduleA/index.js'
+                };
+                runWebpackConfig(
+                    webpackConfig,
+                    done,
+                    'test/modules/moduleA/translation-keys.json',
+                    '{"end":"end","moduleA":"moduleA"}'
+                );
+            });
+
+            it('works with an object with single key and custom output for entry with [name]', done => {
+                webpackConfig.output.filename = '[name]/index.js';
+                webpackConfig.plugins = [
+                    new Plugin({
+                        output: path.join(
+                            __dirname,
+                            'modules/moduleA/[name]/translation-keys.json'
+                        )
+                    })
+                ];
+                runWebpackConfig(
+                    webpackConfig,
+                    done,
+                    'test/modules/moduleA/single/translation-keys.json',
+                    '{"end":"end","moduleA":"moduleA"}'
+                );
+            });
+        });
+
+        describe('with entry array', function() {
+            const webpackConfig = {
+                entry: [
+                    './test/modules/moduleA/index.js',
+                    './test/modules/moduleB/index.js'
+                ],
+                output: {
+                    filename: 'index.js',
+                    path: path.join(__dirname, 'modules')
+                },
+                plugins: [
+                    new Plugin({
+                        output: path.join(
+                            __dirname,
+                            'modules/translation-keys.json'
+                        )
+                    })
+                ]
+            };
+
+            it('works with merging all keys', done => {
+                runWebpackConfig(
+                    webpackConfig,
+                    done,
+                    'test/modules/translation-keys.json',
+                    '{"end":"end","moduleA":"moduleA","moduleB":"moduleB"}'
+                );
+            });
+        });
+
+        describe('with entry object with multiple keys', function() {
+            const webpackConfig = {
+                entry: {
+                    moduleA: './test/modules/moduleA/index.js',
+                    moduleB: './test/modules/moduleB/index.js'
+                },
+                output: {
+                    filename: '[name]/index.js',
+                    path: path.join(__dirname, 'modules')
+                },
+                plugins: [
+                    new Plugin({
+                        output: path.join(
+                            __dirname,
+                            'modules/translation-keys.json'
+                        )
+                    })
+                ]
+            };
+
+            it('works with merging all keys', done => {
+                runWebpackConfig(
+                    webpackConfig,
+                    done,
+                    'test/modules/translation-keys.json',
+                    '{"end":"end","moduleA":"moduleA","moduleB":"moduleB"}'
+                );
+            });
+
+            it('works with splitting keys per entry', done => {
+                webpackConfig.plugins = [
+                    new Plugin({
+                        output: path.join(
+                            __dirname,
+                            'modules/[name]/translation-keys.json'
+                        )
+                    })
+                ];
+                webpack(webpackConfig, error => {
+                    assert.equal(error, null);
+                    const contentA = JSON.stringify(
+                        sortObjectByKeyname(
+                            JSON.parse(
+                                fs.readFileSync(
+                                    'test/modules/moduleA/translation-keys.json',
+                                    'utf8'
+                                )
+                            )
+                        )
+                    );
+                    assert.equal(contentA, '{"end":"end","moduleA":"moduleA"}');
+                    const contentB = JSON.stringify(
+                        sortObjectByKeyname(
+                            JSON.parse(
+                                fs.readFileSync(
+                                    'test/modules/moduleB/translation-keys.json',
+                                    'utf8'
+                                )
+                            )
+                        )
+                    );
+                    assert.equal(contentB, '{"moduleB":"moduleB"}');
+                    done();
+                });
+            });
+        });
+
+        describe('with entry object with multiple keys and array value', function() {
+            const webpackConfig = {
+                entry: {
+                    moduleA: [
+                        './test/modules/moduleA/index.js',
+                        'test/modules/moduleA/transformer/end.js'
+                    ],
+                    moduleB: './test/modules/moduleB/index.js'
+                },
+                output: {
+                    filename: '[name]/index.js',
+                    path: path.join(__dirname, 'modules')
+                },
+                plugins: [
+                    new Plugin({
+                        output: path.join(
+                            __dirname,
+                            'modules/translation-keys.json'
+                        )
+                    })
+                ]
+            };
+
+            it('works with merging all keys', done => {
+                runWebpackConfig(
+                    webpackConfig,
+                    done,
+                    'test/modules/translation-keys.json',
+                    '{"end":"end","moduleA":"moduleA","moduleB":"moduleB"}'
+                );
+            });
+
+            it('works with splitting keys per entry', done => {
+                webpackConfig.plugins = [
+                    new Plugin({
+                        output: path.join(
+                            __dirname,
+                            'modules/[name]/translation-keys.json'
+                        )
+                    })
+                ];
+                webpack(webpackConfig, error => {
+                    assert.equal(error, null);
+                    const contentA = JSON.stringify(
+                        sortObjectByKeyname(
+                            JSON.parse(
+                                fs.readFileSync(
+                                    'test/modules/moduleA/translation-keys.json',
+                                    'utf8'
+                                )
+                            )
+                        )
+                    );
+                    assert.equal(contentA, '{"end":"end","moduleA":"moduleA"}');
+                    const contentB = JSON.stringify(
+                        sortObjectByKeyname(
+                            JSON.parse(
+                                fs.readFileSync(
+                                    'test/modules/moduleB/translation-keys.json',
+                                    'utf8'
+                                )
+                            )
+                        )
+                    );
+                    assert.equal(contentB, '{"moduleB":"moduleB"}');
+                    done();
+                });
+            });
+        });
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -76,7 +76,7 @@ describe('Webpack Extract Translations Keys', function () {
             assert.equal(compiler.hooks.compilation.tap.calledArgs[0][0], 'WebpackExtractTranslationKeys');
             assert.equal(compiler.hooks.done.tap.calledArgs[0][0], 'WebpackExtractTranslationKeys');
             compiler.hooks.done.tap.calledArgs[0][1]();
-            assert.equal(spy.calledArgs[0][0], pl.keys);
+            assert.equal(spy.calledArgs[0][1], pl.keys);
         });
 
         it('should collect translation keys from the expressions', function () {


### PR DESCRIPTION
If ES6 code is a problem here, I can add a transpiling step 🗡 

The main gist is within entryPoints and reverseEntryPoints, else its just moved code and a tiny change to outputMap.

Integration tests are somewhat naive but they reflect what we want I believe