### PR TITLE
Update to webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "Dmitriy Kubyshkin <grassator@gmail.com>",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "webpack": "^4.0.0"
+    "webpack": "^5.0.0"
   },
   "devDependencies": {
     "@types/webpack": "^4.4.22",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "mocha": "^5.2.0",
     "rimraf": "^2.6.3",
     "tranzlate": "1.2.0",
-    "webpack": "^4.16.2"
+    "webpack": "^5.73.0"
   }
 }


### PR DESCRIPTION
Update peer dependencies to support webpack 5, this code , function and package works with webpack 5 as well. Tried and tested on local. 
Update peer dependencies to avoid webpack warnings and errors, causing the build failed. Or support webpack 5 atleast.