### PR TITLE
Update readme for Webpack Compatiablity

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This plugin serves a similar purposes, but instead of replacing translation keys
 
 Approach like this also allows to provide dynamically generated translation bundles to the client allowing you to get real-time updates to translation without regenerating whole client side bundle.
 
+This plugin also compatible with Webpack 5.
+
 ## Usage
 
 ### Configuration


### PR DESCRIPTION
I think it's important to mention that this plugin is compatible with Webpack 5. As a developer I land on multiple plugins and sometimes this small information is missing and we ended up trying that plugin with the new version and breaking our heads.

So just to be more clear let's mentioned this.