### PR TITLE
Use ModuleGraph API to avoid DeprecationWarning: Module.issuer

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,12 @@ const KeyGenerator = require('./key-generator');
 
 // resolve entry for given module, we try to exit early with rawRequest in case of multiple modules issuing request
 function resolveEntry(module, reverseEntryPoints) {
+    const moduleGraph = module.parser.state.compilation.moduleGraph;
     let issuer = module;
     if (reverseEntryPoints[issuer.rawRequest]) {
         return issuer.rawRequest;
     }
-    while (issuer.issuer) {
-        issuer = issuer.issuer;
+    while (issuer = moduleGraph.getIssuer(issuer)) {
         if (reverseEntryPoints[issuer.rawRequest]) {
             return issuer.rawRequest;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpack-extract-translation-keys-plugin",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webpack-extract-translation-keys-plugin",
-      "version": "5.0.2",
+      "version": "6.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/webpack": "^5.28.0",


### PR DESCRIPTION
This patch resolves this warning…

```
[DEP_WEBPACK_MODULE_ISSUER]
DeprecationWarning: Module.issuer: Use new ModuleGraph API
(Use `node --trace-deprecation ...` to show where the warning was
created)
```

…by swapping out module.issuer for moduleGraph.getIssuer(module).