### PR TITLE
Support simple string concatenation in translation key arguments

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,5 +13,6 @@
         "space-before-blocks": ["error", "always"],
         "strict": ["error", "global"],
         "quotes": ["error", "single"]
-    }
+    },
+    "ignorePatterns": ["test/data/*"]
 }

--- a/index.js
+++ b/index.js
@@ -114,8 +114,8 @@ ExtractTranslationPlugin.prototype.apply = function(compiler) {
                                 return false;
                             }
 
-                            key = parser.evaluateExpression(expr.arguments[0]);
-                            if (key.string === undefined) {
+                            key = parser.evaluateExpression(expr.arguments[0]).string;
+                            if (key === undefined) {
                                 parser.state.module.errors.push(
                                     new DynamicTranslationKeyError(
                                         parser.state.module,
@@ -125,7 +125,7 @@ ExtractTranslationPlugin.prototype.apply = function(compiler) {
                                 return false;
                             }
 
-                            let value = key = key.string;
+                            let value = key;
 
                             const entry =
                                 reverseEntryPoints[

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ ExtractTranslationPlugin.prototype.apply = function(compiler) {
                             }
 
                             key = parser.evaluateExpression(expr.arguments[0]);
-                            if (!key.isString()) {
+                            if (key.string === undefined) {
                                 parser.state.module.errors.push(
                                     new DynamicTranslationKeyError(
                                         parser.state.module,
@@ -125,9 +125,7 @@ ExtractTranslationPlugin.prototype.apply = function(compiler) {
                                 return false;
                             }
 
-                            key = key.string;
-
-                            let value = expr.arguments[0].value;
+                            let value = key = key.string;
 
                             const entry =
                                 reverseEntryPoints[

--- a/test/data/simple.js
+++ b/test/data/simple.js
@@ -1,0 +1,2 @@
+const a = __('test.key');
+// {"test.key":"test.key"}

--- a/test/data/string-concat.js
+++ b/test/data/string-concat.js
@@ -1,0 +1,6 @@
+const a = __(
+    'test ' +
+    'string ' +
+    'concat'
+);
+// {"test string concat":"test string concat"}

--- a/test/system-test.js
+++ b/test/system-test.js
@@ -7,42 +7,52 @@ const assert = require('assert');
 const fs = require('fs');
 
 describe('Smoke test for the executable script', function() {
-    beforeEach(() => {
-        fs.writeFileSync('test/test-data.js', 'const a = __(\'test.key\');');
-    });
-
     afterEach(() => {
-        fs.unlinkSync('test/test-data.js');
         if (fs.existsSync('test/output.js')) {
             fs.unlinkSync('test/output.js');
         }
-
         if (fs.existsSync('test/translation-keys.json')) {
             fs.unlinkSync('test/translation-keys.json');
         }
     });
 
     describe('when valid input and output file given', function() {
+        const webpackConfig = {
+            // entry varies per test
+            output: {
+                filename: 'output.js',
+                path: path.join(__dirname, '../test/')
+            },
+            plugins: [
+                new Plugin({
+                    output: path.join(__dirname, 'translation-keys.json')
+                }),
+                new webpack.ProvidePlugin({'__': 'tranzlate'})
+            ]
+        };
+
         it('extracts the keys used in input file', done => {
-            const webpackConfig = {
-                entry: './test/test-data.js',
-                output: {
-                    filename: 'output.js',
-                    path: path.join(__dirname, '../test/')
-                },
-                plugins: [
-                    new Plugin({
-                        output: path.join(__dirname, 'translation-keys.json')
-                    }),
-                    new webpack.ProvidePlugin({'__': 'tranzlate'})
-                ]
-            };
+            webpackConfig.entry = './test/data/simple.js';
+            const expected = '{"test.key":"test.key"}';
 
             webpack(webpackConfig, (error) => {
                 assert.equal(error, null);
 
                 const content = fs.readFileSync('test/translation-keys.json').toString();
-                assert.equal(content, '{"test.key":"test.key"}');
+                assert.equal(content, expected);
+                done();
+            });
+        });
+
+        it('supports string literal concatenation in input file', done => {
+            webpackConfig.entry = './test/data/string-concat.js';
+            const expected = '{"test string concat":"test string concat"}';
+
+            webpack(webpackConfig, (error) => {
+                assert.equal(error, null);
+
+                const content = fs.readFileSync('test/translation-keys.json').toString();
+                assert.equal(content, expected);
                 done();
             });
         });


### PR DESCRIPTION
Allows string literals to be broken up across multiple lines with `+`:
```js
   const textContent = __(
     "We decided to split this translation key " +
     "into multiple lines for code formatting " +
     "purposes..."
   );
```

## Motivation
- **Code readability**: We wanted to break up long string literals to keep line lengths below a threshold (like 80 characters).
- **Restore missing strings**: Keys written this way would appear to be missing from the output:
    ```js
    const a  = __('a');
    const bc = __('bc' + 'bc');
    // Output
    => {"a":"a"}      🫥
    ```
    A few of these slipped past code review because no errors appeared during build.
    I wanted to add a warning, but it was feasible to make it work instead; I like that better.
    ```ts
    // After the fix
    => {"a":"a","bcbc":"bcbc"}
    ```
## The fix
```diff
  // ... in the "parser.hooks.call" hook ...
  key = parser.evaluateExpression(expr.arguments[0]);
- if (!key.isString()) {
+ if (key.string !== undefined) {
     /* (throw dynamic translation key error, unchanged) */
  }
  
-  key = key.string;
-
- let value = expr.arguments[0].value
+ let value = key = key.string;

    /* ... */
```

<details><summary>How it works</summary>

When checking for dynamic key errors, check whether `.string` is defined on the evaluated expression. This is more permissive than `.isString()`, and these now pass the test:

```scheme
(StringLiteral "hi world")       ; "hi world"

(BinaryExpression (+)            ; "hello " + "world"
  (StringLiteral "hello ")
  (StringLiteral "world" ))
  
(BinaryExpression (+)            ; "hello, " + "world" + "!"
  (StringLiteral "hello, ")
   (BinaryExpression (+)
     (StringLiteral "world")
     (StringLiteral "!")))
```

To get the value, use `.string` again. This works for the concatenating examples above, because `parser.evaluateExpression` has done the computation for us. `expr.arguments[0].value` is equivalent in the first case, but it's undefined in the others, so those keys were disappearing: 

```ts
JSON.stringify({
  "hi world": "hi world",
  "hello world": undefined,
  "hello, world!": undefined,
})
// `{"hi world":"hi world"}`
```
</details>

## Test coverage

Existing tests pass. I added this one:[^1]

```ts
const a = __(
    'test ' +
    'string ' +
    'concat'
);
// {"test string concat":"test string concat"}
```

[^1]: If you'd like me to revise the test case (to fit the existing code structure, or to be more succinct), let me know.